### PR TITLE
chore: add deployment readiness checks in workflow

### DIFF
--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -64,10 +64,21 @@ jobs:
             helm dep up charts/edc-kafka-demo
             
             helm install demo charts/edc-kafka-demo -n demo --create-namespace \
-            --wait --timeout=300s --dependency-update
+            --wait --dependency-update
+            
+            # Wait for deployments to be ready
+            kubectl rollout status deployment demo-consumer-edc-controlplane -n demo
+            kubectl rollout status deployment demo-producer-edc-dataplane -n demo
+            kubectl rollout status deployment demo-producer-edc-controlplane -n demo
+            kubectl rollout status deployment demo-consumer-edc-dataplane -n demo
+            kubectl rollout status deployment demo-consumer-app -n demo
+            kubectl rollout status deployment demo-producer-app -n demo
             
             # Get deployment status
             kubectl get deployment -n demo
+            
+            # Wait for the producer to publish the first messages
+            sleep 5
             
             # execute the helm test
             helm test demo -n demo


### PR DESCRIPTION
## Description
add deployment readiness checks in workflow

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
